### PR TITLE
Create full About Us page

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -94,7 +94,10 @@ $app->get(
 $app->get(
     '/about',
     function () use ($app) {
-        return $app->redirect('/', 301);
+        return $app['twig']->render(
+            'about.twig',
+            array()
+        );
     }
 );
 

--- a/views/about.twig
+++ b/views/about.twig
@@ -47,11 +47,7 @@
                     </ul>
                 </li>
                 <li><a href="#sponsorship">Sponsorship</a></li>
-                <li><a href="#about-this">About this document</a>
-                    <ul>
-                        <li><a href="#license">License</a></li>
-                    </ul>
-                </li>
+                <li><a href="#about-this">About this document</a></li>
             </ul>
 
             <h2><a name="code-of-conduct">Code of Conduct</a></h2>
@@ -173,9 +169,6 @@
             <p>This document was taken from the <a href="http://lrug.org/">LRUG.org</a> Readme, and modified for PHPDorset.  It is supposed to be a living document and as such contributions
             are welcome via our <a href="https://github.com/PHPDorset/phpdorset.github.io">Github repository</a></p>
 
-            <h3><a name="license">License</a></h3>
-
-            <p>This text is licensed as <a href="http://creativecommons.org/about/cc0">CC0</a>; in summary, it is in the public domain and can be used and modified with or without attribution.</p>
         </div>
     </div>
 </div>

--- a/views/about.twig
+++ b/views/about.twig
@@ -15,13 +15,13 @@
     <div class="inner clearfix">
         <div class="about">
 
-            <p>PHPDorset is a Bournemouth based community for anyone interested in the PHP programming language, or web development in general</p>
+            <p>PHPDorset is a Bournemouth based community for anyone interested in the PHP programming language, or web development in general.</p>
 
             <p>PHPDorset provides online and offline opportunities to:
                 <ul>
                     <li>discuss PHP and related topics</li>
                     <li>socialise with friendly people who are interested in PHP</li>
-                    <li>find or fill PHP-related jobs</li>
+                    <li>find or fill PHP related jobs</li>
                 </ul>
             </p>
 
@@ -39,7 +39,7 @@
                         <li><a href="#talks">Talks</a>
                             <ul>
                                 <li><a href="#scheduling">Scheduling</a></li>
-                                <li><a href="#subject-matter">Subject Matter</a></li>
+                                <li><a href="#subject-matter">Subject matter</a></li>
                                 <li><a href="#timing">Timing</a></li>
                                 <li><a href="#after-talks">After the talks</a></li>
                             </ul>
@@ -89,14 +89,15 @@
 
             <h2><a name="meetings">Meetings</a></h2>
 
-            <p>We meet once a month at St. Ambrose Church hall in Westbourne, usually on the first Monday (although we shift to the second Monday for bank holidays) from 7.30pm.
+            <p>We meet once a month at <a href="https://www.google.co.uk/maps/place/St+Ambrose+Church/@50.7176004,-1.9018998,17.11z/data=!4m2!3m1!1s0x4873a1a57458cc11:0xf5803aef30b9ec8b">St. Ambrose Church hall in Westbourne</a>,
+            usually on the first Monday (although we shift to the second Monday for bank holidays) from 7.30pm.
             There are typically two talks and then we go to the pub. There’s always tea and coffee at St. Ambrose, and usually there’ll be pizza; beer is limited to the pub afterwards.</p>
 
             <p>To stay informed about our upcoming meetings you can:
                 <ul>
                     <li>follow <a href="https://twitter.com/phpdorset">@phpdorset</a></li>
                     <li>follw us on <a href="http://www.eventbrite.co.uk/o/phpdorset-5284449005">Eventbrite</a></li>
-                    <li>check out IRC #phpdorset</li>
+                    <li>check out <a href="https://webchat.freenode.net/">IRC</a> #phpdorset</li>
                 </ul>
             </p>
 
@@ -119,7 +120,7 @@
 
             <p>If there is a specific future meeting that would be most convenient for you, let us know and we’ll do our best to accommodate that.</p>
 
-            <h4><a name="subject-matter">Subject Matter</a></h4>
+            <h4><a name="subject-matter">Subject matter</a></h4>
 
             <p>PHPDorset is a mixed-ability crowd; we have talks from first-timers just learning PHP all the way up to people that have been using it for years.
             This means you can pitch your talk at any level and someone will get something out of it. It’s also a mostly technical crowd, so don’t shy away
@@ -138,11 +139,11 @@
 
             <p>A slot isn’t how long your talk should be, but how much time you will get in front of the group. You can fill that time slot as you see fit (talk + questions, talk only, etc).</p>
 
-            <p>If you have a talk idea but feel it is too long or too short for our normal slots, please speak to us as we are always willing to discuss how we could work it into our meetings</p>
+            <p>If you have a talk idea but feel it is too long or too short for our normal slots, please speak to us as we are always willing to discuss how we could work it into our meetings.</p>
 
-            <h3><a name="after-talks">After The Talks</a></h3>
+            <h3><a name="after-talks">After the talks</a></h3>
 
-            <p>When the talks are finished, usually around 9pm, most of the group head over to Camden. This part of the meeting is your opportunity to socialise with other PHPDorset members and speak with the presenters about their talks.</p>
+            <p>When the talks are finished, usually around 9pm, most of the group head over to <a href="https://www.google.co.uk/maps/place/Camden+Bar+Westbourne/@50.7222634,-1.9064786,17z/data=!3m1!4b1!4m2!3m1!1s0x4873a1a1186a32f9:0x6d74683f295a1d3e">Camden Bar</a>. This part of the meeting is your opportunity to socialise with other PHPDorset members and speak with the presenters about their talks.</p>
 
             <p>Just because we’re in a pub doesn’t mean you have to drink alcohol. If you do choose to drink alcohol we encourage you to explore the food menu and drink responsibly.</p>
 
@@ -159,7 +160,7 @@
                     <li>put your logo in the sponsor side-bar on the relevant meeting page on phpdorset.co.uk</li>
                     <li>mention the specifics of your sponsorship in the main details of the relevant meeting page on phpdorset.co.uk</li>
                     <li>mention the sponsorship in the meeting announcement email on the mailing list</li>
-                    <li>tweet about the sponsorship from @phodorset at least once to announce it and once on the day as a reminder</li>
+                    <li>tweet about the sponsorship from @phpdorset at least once to announce it and once on the day as a reminder</li>
                     <li>mention you at the start of the meeting, and make sure you have 30seconds or so during our announcements section to talk to the group</li>
                 </ul>
             </p>

--- a/views/about.twig
+++ b/views/about.twig
@@ -1,14 +1,181 @@
 {% extends "master.twig" %}
 
 {% block main_content %}
-    <div class="inner cover">  
-        
-    	<h1>About PHP Dorset</h1>
+<div id="strapline">
+    <div class="wrapper">
 
-    	<p>
-    		PHP Dorset is a local user group, open to all.
-            We have monthly talks followed by a social. We usually hold our talks on the first Monday of the month at <a href="https://www.google.com/maps/place/Westbourne+Library/@50.721794,-1.902,17z" target="_blank">Westbourne Library</a> and then our social event is held at the <a href="https://www.google.com/maps/place/The+Libertine/@50.722335,-1.904852,17z" target="_blank">Libertine Pub</a> in Westbourne.
-    	</p>
+        <p>
+            PHP Dorset is a local user group, open to all. Monthly talk and meet on the first Monday of the month in Westbourne, Dorset.
+        </p>
 
     </div>
+</div>
+
+<div class="banner">
+    <div class="inner clearfix">
+        <div class="about">
+
+            <p>PHPDorset is a Bournemouth based community for anyone interested in the PHP programming language, or web development in general</p>
+
+            <p>PHPDorset provides online and offline opportunities to:
+                <ul>
+                    <li>discuss PHP and related topics</li>
+                    <li>socialise with friendly people who are interested in PHP</li>
+                    <li>find or fill PHP-related jobs</li>
+                </ul>
+            </p>
+
+            <p>We want PHPDorset to be a diverse and inclusive community, united by an interest in PHP, and so we want anyone who is interested in PHP to be able to participate.</p>
+
+            <ul>
+                <li><a href="#code-of-conduct">Code of Conduct</a>
+                    <ul>
+                        <li><a href="#incident-handling">Incident Handling</a></li>
+                    </ul>
+                </li>
+                <li><a href="#volunteers">Volunteer Team</a></li>
+                <li><a href="#meetings">Meetings</a>
+                    <ul>
+                        <li><a href="#talks">Talks</a>
+                            <ul>
+                                <li><a href="#scheduling">Scheduling</a></li>
+                                <li><a href="#subject-matter">Subject Matter</a></li>
+                                <li><a href="#timing">Timing</a></li>
+                                <li><a href="#after-talks">After the talks</a></li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li><a href="#sponsorship">Sponsorship</a></li>
+                <li><a href="#about-this">About this document</a>
+                    <ul>
+                        <li><a href="#license">License</a></li>
+                    </ul>
+                </li>
+            </ul>
+
+            <h2><a name="code-of-conduct">Code of Conduct</a></h2>
+
+            <p>It is of primary importance that everyone who wants to participate feels safe and welcome. When participating in PHPDorset, either online or offline, at St Ambrose or at the pub afterwards, we expect you to:
+                <ul>
+                    <li>behave respectfully towards other people — they’re real humans, just like you</li>
+                    <li>be considerate of people’s time and attention</li>
+                    <li>contribute positively and constructively to discussions (online or in-person)</li>
+                </ul>
+            </p>
+
+            <h3><a name="incident-handling">Incident Handling</a></h3>
+
+            <p>We want everyone to feel welcome at PHPDorset, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion.
+            Accordingly, we will not tolerate harassment of our members in any form; not at the talks, not at the pub after the talks, or any other PHPDorset social meeting; not on Twitter or on any other online media.</p>
+
+            <p>Harassment includes invasions of personal space, exclusionary jokes/comments, and sexual language and imagery in talks, but this list is non-exhaustive:
+            if you make anyone feel uncomfortable or unwelcome, you will be asked to leave.</p>
+
+            <p>If you’re still in need of clarification, there are a number of good resources online which we encourage you read. The main thing to remember though,
+            is that if someone feels harassed or excluded by your words or actions, then those words or actions constitute harassment or exclusion. <em>Your intent is not a factor</em>.</p>
+
+            <p>All PHPDorset participants are accountable for their own behaviour. If you’ve behaved badly elsewhere, that may count against you here, because of the effect it has on other attendees.</p>
+
+            <p>If you experience or witness any harassing behaviour, please report it to a member of the <a href="#volunteers">volunteer team</a>.</p>
+
+            <h2><a name="volunteers">Volunteer Team</a></h2>
+            <ul>
+                <li><a href="https://twitter.com/dave1010">Dave Hulbert / @dave1010</a></li>
+                <li><a href="https://twitter.com/rossey">Alex Ross / @rossey</a></li>
+                <li><a href="https://twitter.com/hughbertd">Hugh Downer / @HughbertD</a></li>
+                <li><a href="https://twitter.com/fully_baked">Dave Baker / @fully_baked</a></li>
+            </ul>
+
+            <h2><a name="meetings">Meetings</a></h2>
+
+            <p>We meet once a month at St. Ambrose Church hall in Westbourne, usually on the first Monday (although we shift to the second Monday for bank holidays) from 7.30pm.
+            There are typically two talks and then we go to the pub. There’s always tea and coffee at St. Ambrose, and usually there’ll be pizza; beer is limited to the pub afterwards.</p>
+
+            <p>To stay informed about our upcoming meetings you can:
+                <ul>
+                    <li>follow <a href="https://twitter.com/phpdorset">@phpdorset</a></li>
+                    <li>follw us on <a href="http://www.eventbrite.co.uk/o/phpdorset-5284449005">Eventbrite</a></li>
+                    <li>check out IRC #phpdorset</li>
+                </ul>
+            </p>
+
+            <h3><a name="talks">Talks</a></h3>
+
+            <p>Most of our meetings have talks from community members and we’re always looking for people to give a talk.
+            If you’d like to give a talk you should get in touch with us (@phpdorset, phpdorset@gmail.com) and suggest it.</p>
+
+            <p>Our goal is to accept any offered talk. If your talk is obviously about PHP there’s no question about it; you can definitely give your talk.
+            If it’s not so obviously about PHP we’ll have a discussion first to see what the hook is for PHP developers. We’re quite an open-minded group,
+            so the hook doesn’t have to be that clear. In the unlikely event that it turns out that PHP Dorset isn’t a good home for your talk, we’ll do our best to come up with
+            some alternative ideas for places you could give it.</p>
+
+            <h4><a name="scheduling">Scheduling</a></h4>
+
+            <p>Slots for talks are first-come, first-served. Once you’ve decided to give your talk we’ll let you know when a free slot
+            will be available at a meeting. We usually have two talks per meeting, so if there are 4 people on our list of volunteers
+            when you offer your talk it’s most likely that the third meeting is the one we’d schedule you for. Of course, people drop out
+            or aren’t available for a specific meeting so you might get a slot sooner.</p>
+
+            <p>If there is a specific future meeting that would be most convenient for you, let us know and we’ll do our best to accommodate that.</p>
+
+            <h4><a name="subject-matter">Subject Matter</a></h4>
+
+            <p>PHPDorset is a mixed-ability crowd; we have talks from first-timers just learning PHP all the way up to people that have been using it for years.
+            This means you can pitch your talk at any level and someone will get something out of it. It’s also a mostly technical crowd, so don’t shy away
+            from getting into the nitty gritty of your topic. We’d prefer an in-depth discussion of a single aspect to a shallow overview of the whole thing.</p>
+
+            <p>Your talk should observe the code of conduct. Any talks that don’t will be stopped and the speaker asked to leave.</p>
+
+            <p>If you are using the projector you should favour large fonts and a high contrast colour scheme with dark text on a light background in anything you show.
+            The default settings for most presentation applications are a safe bet, but you might have to re-configure your terminal or editor if you are using those for anything.
+            Also note that while the projector will cope with most screen resolutions, it works best at 1024x768. Most presentation applications will automatically resize,
+            but you might want to check your slides at that resolution.</p>
+
+            <h4><a name="timing">Timing</a></h4>
+
+            <p>Our normal pattern for a meeting is two speakers with 45 minute time slot and a 25 minute slot, although one-off meetings might be different.</p>
+
+            <p>A slot isn’t how long your talk should be, but how much time you will get in front of the group. You can fill that time slot as you see fit (talk + questions, talk only, etc).</p>
+
+            <p>If you have a talk idea but feel it is too long or too short for our normal slots, please speak to us as we are always willing to discuss how we could work it into our meetings</p>
+
+            <h3><a name="after-talks">After The Talks</a></h3>
+
+            <p>When the talks are finished, usually around 9pm, most of the group head over to Camden. This part of the meeting is your opportunity to socialise with other PHPDorset members and speak with the presenters about their talks.</p>
+
+            <p>Just because we’re in a pub doesn’t mean you have to drink alcohol. If you do choose to drink alcohol we encourage you to explore the food menu and drink responsibly.</p>
+
+            <p>Although the venue for this part of the meeting is a pub and therefore feels more informal, be aware that the code of conduct still applies.</p>
+
+            <h3><a name="sponsors">Sponsorship</a></h3>
+
+            <p>PHPDorset is sponsored by <a href="http://www.spectrumit.co.uk/">SpectrumIT</a> who cover the venue and pizzas. We don’t currently need venue sponsorship or an alternate venue or main sponsor.</p>
+
+            <p>There are opportunities for drinks sponsorship during the meeting, or bar-tab sponsorship after the meeting at the pub. If you would like to provide sponsorship you should get in touch with us (@phpdorset, phpdorset@gmail.com) to find out the prices and arrange it.</p>
+
+            <p>In return for your sponsorship PHPDorset will:
+                <ul>
+                    <li>put your logo in the sponsor side-bar on the relevant meeting page on phpdorset.co.uk</li>
+                    <li>mention the specifics of your sponsorship in the main details of the relevant meeting page on phpdorset.co.uk</li>
+                    <li>mention the sponsorship in the meeting announcement email on the mailing list</li>
+                    <li>tweet about the sponsorship from @phodorset at least once to announce it and once on the day as a reminder</li>
+                    <li>mention you at the start of the meeting, and make sure you have 30seconds or so during our announcements section to talk to the group</li>
+                </ul>
+            </p>
+
+            <p>We also have community sponsorship from <a href="https://www.jetbrains.com/">Jetbrains</a>, who provide free licenses to their awesome
+            software for our competitions, and from <a href="http://www.oreilly.com/">O'Reilly</a> books who provide a user group discount for our members</p>
+
+            <h2><a name="about-this">About this document</a></h2>
+
+            <p>This document was taken from the <a href="http://lrug.org/">LRUG.org</a> Readme, and modified for PHPDorset.  It is supposed to be a living document and as such contributions
+            are welcome via our <a href="https://github.com/PHPDorset/phpdorset.github.io">Github repository</a></p>
+
+            <h3><a name="license">License</a></h3>
+
+            <p>This text is licensed as <a href="http://creativecommons.org/about/cc0">CC0</a>; in summary, it is in the public domain and can be used and modified with or without attribution.</p>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/views/navigation.twig
+++ b/views/navigation.twig
@@ -2,4 +2,5 @@
     <li {% if app.current_url == '/' %} class="active" {% endif %}><a href="/">Events</a></li>
     <li {% if app.current_url matches '^/talk(.*)^' %} class="active" {% endif %}><a href="/talks">Talks</a></li>
     <li {% if app.current_url == '/get-involved' %} class="active" {% endif %}><a href="/get-involved">Get Involved</a></li>
+    <li {% if app.current_url == '/about' %} class="active" {% endif %}><a href="/about">About Us</a></li>
 </ul>

--- a/web/stylesheets/style.css
+++ b/web/stylesheets/style.css
@@ -108,6 +108,13 @@ h1{
     width:60%;
 }
 
+.banner .inner .about{
+    margin-left:auto;
+    margin-right:auto;
+    text-align:left;
+    width:40%;
+}
+
 .clearfix:after{content: ".";display:block;height:1%;clear:both;visibility:hidden;margin:0;line-height:0.1em;}
 
 .banner div.col-1{


### PR DESCRIPTION
I've made this as a PR rather than committing straight to the repo as I want a second (or more) set of eyes on it.

This is a full about us page that I've been intending to do for a while, including info about 
- talk slots
- new venue
- first Monday except bank hols
- new code of conduct
- sponsorship stuff 

It's taken from the README at LRUG.org (London Ruby user group), which I think is really good.  

Please, can someone else read through and we get an agreement that this is a good idea before it gets merged in ;)
