### PR TITLE
Fix link for eventbrite

### DIFF
--- a/views/about.twig
+++ b/views/about.twig
@@ -98,7 +98,7 @@
         <p>To stay informed about our upcoming meetings you can:</p>
         <ul>
             <li>follow us on twitter <a href="https://twitter.com/PHP Dorset">@PHPDorset</a></li>
-            <li>follow us on <a href="http://www.eventbrite.co.uk/o/PHPDorset-5284449005">Eventbrite</a></li>
+            <li>follow us on <a href="https://phpdorset.eventbrite.co.uk">Eventbrite</a></li>
             <li>join us on <a href="https://slackin-phpdorset.herokuapp.com/">Slack</a></li>
         </ul>
 


### PR DESCRIPTION
Exactly what it says on the tin.

Could be when we moved eventbrite users the resolved link was no longer valid, not sure. But the phpdorset.eventbrite.co.uk link seems to work and resolve to a new url.