### PR TITLE
Parking is no longer free :-(

### DIFF
--- a/views/homepage.twig
+++ b/views/homepage.twig
@@ -8,7 +8,7 @@
         <iframe src="https://www.google.com/maps/embed/v1/place?q=Barclays+Eagle+Labs+Bournemouth,+Poole+Road,+Branksome,+Poole,+United+Kingdom&key=AIzaSyDlEVWcPvkrfzqpzW9L_ARUhsqWxSTAx60" width="600" height="450" frameborder="0" style="border:0"></iframe>
         <div class="map-overlay">
             <p>PHP Dorset is at the <strong>Barclays Eagle Labs</strong> starting at <strong>6.30pm</strong>.</p>
-            <p>Free parking is available from 6pm at <a href="http://en.parkopedia.co.uk/parking/carpark/milburn_road/bh4/bournemouth/">Milburn Road</a>.</p>
+            <p>Parking is available from 6pm at <a href="http://en.parkopedia.co.uk/parking/carpark/milburn_road/bh4/bournemouth/">Milburn Road</a>.</p>
         </div>
     </div>
 


### PR DESCRIPTION
@stuartherbert mentioned that parking isn't free at Milburn Road car park in the evenings. Parkopedia says the same.

Correcting the website for now. Later we could add details of free parking on roads that are a 10 minute walk away.