### PR TITLE
Adds CSP Header

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -3,12 +3,14 @@
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+define('CSP_NONCE', base64_encode(random_bytes(16)));
+
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $app = new Silex\Application();
 
 $app->after(function (Request $request, Response $response) {
-    $response->headers->set('Content-Security-Policy', 'default-src \'self\'; font-src \'self\' http://netdna.bootstrapcdn.com; img-src \'self\'; frame-src https://www.google.com; script-src \'self\' https://ajax.googleapis.com http://netdna.bootstrapcdn.com; style-src \'self\' http://netdna.bootstrapcdn.com');
+    $response->headers->set('Content-Security-Policy', 'default-src \'self\'; font-src \'self\' https://netdna.bootstrapcdn.com; img-src \'self\'; frame-src https://www.google.com; script-src \'self\' \'nonce-' . CSP_NONCE . '\' https://www.google-analytics.com https://ajax.googleapis.com https://netdna.bootstrapcdn.com https://oss.maxcdn.com; style-src \'self\' https://netdna.bootstrapcdn.com');
 });
 
 $app['current_url'] = function ($app) {
@@ -21,6 +23,9 @@ $app->register(
         'twig.path' => __DIR__ . '/../views',
     )
 );
+
+$app["twig"]->addGlobal('CSP_NONCE', CSP_NONCE);
+
 
 $app->register(new Silex\Provider\ServiceControllerServiceProvider());
 

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -107,5 +107,8 @@ $app->get(
     }
 );
 
+$app->error(function (\Exception $e, Request $request, $code) use ($app) {
+    return new Response($app['twig']->resolveTemplate('errors/404.twig')->render([]), $code);
+});
 
 return $app;

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -1,8 +1,15 @@
 <?php
 
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $app = new Silex\Application();
+
+$app->after(function (Request $request, Response $response) {
+    $response->headers->set('Content-Security-Policy', 'default-src \'self\'; font-src \'self\' http://netdna.bootstrapcdn.com; img-src \'self\'; frame-src https://www.google.com; script-src \'self\' https://ajax.googleapis.com http://netdna.bootstrapcdn.com; style-src \'self\' http://netdna.bootstrapcdn.com');
+});
 
 $app['current_url'] = function ($app) {
     return $app['request_stack']->getCurrentRequest()->server->get('REQUEST_URI');

--- a/views/errors/404.twig
+++ b/views/errors/404.twig
@@ -1,0 +1,14 @@
+{% extends "master.twig" %}
+
+{% block main_content %}
+    <div id="strapline">
+        <div class="wrapper">
+            <p>
+                PHP Dorset is a Bournemouth based community for anyone interested in the PHP programming language, or web development in general.
+            </p>
+        </div>
+    </div>
+<div class="inner">
+    <h3>Page Not Found</h3>
+</div>
+{% endblock %}

--- a/views/homepage.twig
+++ b/views/homepage.twig
@@ -5,7 +5,7 @@
     {% include 'homepage/cta.twig' %}
 
     <div class="google-maps">
-        <iframe src="https://www.google.com/maps/embed/v1/place?q=Barclays+Eagle+Labs+Bournemouth,+Poole+Road,+Branksome,+Poole,+United+Kingdom&key=AIzaSyDlEVWcPvkrfzqpzW9L_ARUhsqWxSTAx60" width="600" height="450" frameborder="0" style="border:0"></iframe>
+        <iframe src="https://www.google.com/maps/embed/v1/place?q=Barclays+Eagle+Labs+Bournemouth,+Poole+Road,+Branksome,+Poole,+United+Kingdom&key=AIzaSyDlEVWcPvkrfzqpzW9L_ARUhsqWxSTAx60" width="600" height="450" frameborder="0"></iframe>
         <div class="map-overlay">
             <p>PHP Dorset is at the <strong>Barclays Eagle Labs</strong> starting at <strong>6.30pm</strong>.</p>
             <p>Parking is available from 6pm at <a href="http://en.parkopedia.co.uk/parking/carpark/milburn_road/bh4/bournemouth/">Milburn Road</a>.</p>

--- a/views/master.twig
+++ b/views/master.twig
@@ -24,19 +24,19 @@
     <![endif]-->
 
 
-    <script>
+    <script nonce="{{ CSP_NONCE }}">
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
         ga('create', 'UA-50716707-1', 'phpdorset.co.uk');
         ga('send', 'pageview');
 
     </script>
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js" integrity="sha384-/Gm+ur33q/W+9ANGYwB2Q4V0ZWApToOzRuA8md/1p9xMMxpqnlguMvk8QuEFWA1B" crossorigin="anonymous"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT" crossorigin="anonymous"></script>
 
-    <script>
+    <script nonce="{{ CSP_NONCE }}">
         $(function () {
             $('div#masthead span.phpdorset-logo a').bind('contextmenu', function () {
                 $('div#press-kit').slideToggle();
@@ -55,7 +55,7 @@
 
 <div class="site-wrapper">
 
-    <div id="press-kit" class="wrapper" style="display:none">
+    <div id="press-kit" class="wrapper">
         <p>Hello! It looks like your trying to download the logo for PHP Dorset, would you like the high-res version?</p>
         <p>
             <a href="https://onedrive.live.com/redir?resid=3FD058F9748E21C3!151&authkey=!AMGS0k_OZIQWdtg&ithint=file%2czip" class="btn">

--- a/views/talk.twig
+++ b/views/talk.twig
@@ -4,7 +4,7 @@
 
     <script src="/scripts/popcorn-complete.min.js"></script>
 
-    <script type="application/javascript">
+    <script nonce="{{ CSP_NONCE }}" type="application/javascript">
 
         {% if talk.cues is not empty %}
 


### PR DESCRIPTION
This PR adds a CSP header.

Things of note:

- JQuery went from v1 to v3. This is because v1 injected script tags which evaluate inline violating the `unsafe-inline` policy
- A 404 template was added. This was to allow the main, CSP verified, content to be rendered