### PR TITLE
Fix github repository link

### DIFF
--- a/views/about.twig
+++ b/views/about.twig
@@ -178,7 +178,7 @@
         <h3><a name="about-this">About this document</a></h3>
 
         <p>This document was taken from the <a href="http://lrug.org/">LRUG.org</a> Readme, and modified for PHP Dorset.  It is supposed to be a living document and as such contributions
-        are welcome via our <a href="https://github.com/PHP Dorset/PHP Dorset.github.io">Github repository</a></p>
+        are welcome via our <a href="https://github.com/PHPDorset/phpdorset.github.io">Github repository</a></p>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR fixes the Github repository link in the About Us page. 