### PR TITLE
Lazy Load Images

### DIFF
--- a/views/homepage/sponsors.twig
+++ b/views/homepage/sponsors.twig
@@ -6,7 +6,7 @@
 
         <div>
             <a href="https://www.spectrumit.co.uk/">
-                <img src="/images/spectrum.jpg" alt="Spectrum"/>
+                <img src="/images/spectrum.jpg" alt="Spectrum" loading="lazy"/>
                 <h6>Spectrum IT</h6>
             </a>
 
@@ -15,7 +15,7 @@
 
         <div>
             <a href="https://shop.oreilly.com/">
-                <img src="/images/orm.jpg" alt="O'Reilly User Group Program"/>
+                <img src="/images/orm.jpg" alt="O'Reilly User Group Program" loading="lazy"/>
                 <h6>O'Reilly User Group Program</h6>
             </a>
 
@@ -25,7 +25,7 @@
 
         <div>
             <a href="https://www.jetbrains.com/phpstorm/">
-                <img src="/images/logo_phpstorm.png" alt="JetBrains PhpStorm"/>
+                <img src="/images/logo_phpstorm.png" alt="JetBrains PhpStorm" loading="lazy"/>
                 <h6>JetBrains PhpStorm</h6>
             </a>
 

--- a/views/talk_list.twig
+++ b/views/talk_list.twig
@@ -25,7 +25,7 @@
 
                     <div class="pod">
                         {% if talk.avatar %}
-                            <img class="circle large" src="{{ talk.avatar }}"/>
+                            <img class="circle large" src="{{ talk.avatar }}" loading="lazy"/>
                         {% endif %}
 
                         <h3>{{ talk.title }}</h3>


### PR DESCRIPTION
This PR adds the `loading="lazy"` to a couple of images.

This change makes the biggest difference on the talks page, throttling the bandwidth to "Regular 3G" the load time went from ~25s to ~2s